### PR TITLE
Some necessary include fixes (spotted by gcc 6.3 on centos7).

### DIFF
--- a/contour/helper.h
+++ b/contour/helper.h
@@ -17,6 +17,7 @@
 #define O2_MCH_CONTOUR_HELPER_H
 
 #include <cmath>
+#include <limits>
 
 namespace o2 {
 namespace mch {

--- a/contour/test/testContourCreator.cxx
+++ b/contour/test/testContourCreator.cxx
@@ -32,7 +32,6 @@
 #include <chrono>
 #include <iostream>
 #include "contourCreator.h"
-#include "svg.h"
 
 using namespace o2::mch::contour;
 

--- a/contour/test/testContourCreatorVsAliRoot.cxx
+++ b/contour/test/testContourCreatorVsAliRoot.cxx
@@ -12,20 +12,6 @@
 ///
 /// @author  Laurent Aphecetche
 
-
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
-//
-// See https://alice-o2.web.cern.ch/ for full licensing information.
-//
-// In applying this license CERN does not waive the privileges and immunities
-// granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.
-
-///
-/// @author  Laurent Aphecetche
-
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
@@ -48,7 +34,6 @@
 #include "AliMpSegmentation.h"
 #include "AliMpVSegmentation.h"
 #include "contourCreator.h"
-#include "svg.h"
 #include <TArrayD.h>
 #include <boost/format.hpp>
 #include <chrono>
@@ -249,8 +234,8 @@ bool areTheSame(const std::pair<Contour<double>, Contour<double>>& contours)
     std::cout << '\n';
     std::cout << contours.first.getSortedVertices().size() << " " << contours.first.getSortedVertices() << '\n';
     std::cout << contours.second.getSortedVertices().size() << " " << contours.second.getSortedVertices() << '\n';
-    basicSVG("fromaliroot.svg", contours.first);
-    basicSVG("fromo2.svg", contours.second);
+    //basicSVG("fromaliroot.svg", contours.first);
+    //basicSVG("fromo2.svg", contours.second);
     return false;
   }
 }

--- a/jsonmap/codegen/codeWriter.cxx
+++ b/jsonmap/codegen/codeWriter.cxx
@@ -11,6 +11,7 @@
 #include "codeWriter.h"
 #include <fstream>
 #include <sstream>
+#include <algorithm>
 
 std::string mappingNamespaceBegin()
 {

--- a/jsonmap/codegen/detectionElement.cxx
+++ b/jsonmap/codegen/detectionElement.cxx
@@ -15,6 +15,7 @@
 #include <vector>
 #include <sstream>
 #include "codeWriter.h"
+#include <algorithm>
 
 using namespace rapidjson;
 

--- a/jsonmap/codegen/segmentation.cxx
+++ b/jsonmap/codegen/segmentation.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <array>
 #include <vector>
+#include <algorithm>
 
 using rapidjson::Value;
 

--- a/jsonmap/creator/de.cxx
+++ b/jsonmap/creator/de.cxx
@@ -6,6 +6,7 @@
 #include "bp.h"
 #include "seg.h"
 #include "AliMpSegmentation.h"
+#include <algorithm>
 
 std::vector<int> get_deids(AliMpDDLStore* /*ddlStore*/)
 {

--- a/jsonmap/creator/motif.cxx
+++ b/jsonmap/creator/motif.cxx
@@ -25,6 +25,7 @@
 #include "padsize.h"
 #include <sstream>
 #include <cassert>
+#include <algorithm>
 
 int get_padsize_index(float px, float py, const std::vector<std::pair<float, float>>& padsizes)
 {

--- a/jsonmap/creator/motif.h
+++ b/jsonmap/creator/motif.h
@@ -17,6 +17,7 @@
 #define ALO_JSONMAP_CREATOR_MOTIF_H
 
 #include <vector>
+#include <string>
 
 class AliMpPCB;
 

--- a/jsonmap/creator/padsize.cxx
+++ b/jsonmap/creator/padsize.cxx
@@ -22,6 +22,7 @@
 #include "AliMpVPadIterator.h"
 #include "AliMpVSegmentation.h"
 #include <iostream>
+#include <memory>
 
 std::vector<std::pair<float,float>> get_padsizes(AliMpDDLStore* ddlStore, AliMpSegmentation* mseg) {
 

--- a/jsonmap/creator/seg.cxx
+++ b/jsonmap/creator/seg.cxx
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <cassert>
 #include <set>
+#include <algorithm>
 
 bool is_slat(std::string segtype) {
     return (segtype.find("st") == std::string::npos);

--- a/jsonmap/creator/test/mapping.cxx
+++ b/jsonmap/creator/test/mapping.cxx
@@ -17,6 +17,7 @@
 #include "de.h"
 #include "seg.h"
 #include "mapping.h"
+#include <algorithm>
 
 Mapping::Mapping()
 {


### PR DESCRIPTION
Note that svg.h is no longer included in any test as the boost geometry includes make gcc 6 very unhappy ... (see https://svn.boost.org/trac10/ticket/9240). Did not want to investigate further.