### PR TITLE
MCH: improve formatting of generated code

### DIFF
--- a/o2/mch/mapping/codegen/cathodeSegmentation2.cxx
+++ b/o2/mch/mapping/codegen/cathodeSegmentation2.cxx
@@ -51,10 +51,13 @@ int detElemId2SegType(int detElemId)
   impl << generateCodeForCatSegTypeArray(catsegs, detection_elements);
 
   impl << R"(
-  int detElemIndex = std::distance(detElemIndexToDetElemId.begin(),
-                                   std::find(detElemIndexToDetElemId.begin(), detElemIndexToDetElemId.end(),
-                                             detElemId));
-  return (detElemIndex>=0 && detElemIndex<156) ? detElemIndexToSegType[detElemIndex] : -1;
+  int detElemIndex =
+    std::distance(detElemIndexToDetElemId.begin(),
+                  std::find(detElemIndexToDetElemId.begin(),
+                            detElemIndexToDetElemId.end(), detElemId));
+  return (detElemIndex>=0 && detElemIndex<156) 
+           ? detElemIndexToSegType[detElemIndex] 
+           : -1;
 }
   )";
   return impl.str();
@@ -166,15 +169,15 @@ void generateCodeForCathodeSegmentationCreator(const std::string& ns, int segTyp
   impl << "CathodeSegmentation* " << creatorName << "(bool isBendingPlane) {\n";
 
   impl << "  if (isBendingPlane) { \n";
-  impl << "    return new CathodeSegmentation{" << segType << ",true," << codeForBendingCtor << "};\n}\n";
+  impl << "    return new CathodeSegmentation{\n" << segType << ",\ntrue," << codeForBendingCtor << "};\n}\n";
   impl << "  else {\n ";
-  impl << "   return new CathodeSegmentation{" << segType << ",false," << codeForNonBendingCtor << "};\n}\n";
+  impl << "   return new CathodeSegmentation{\n" << segType << ",\nfalse," << codeForNonBendingCtor << "};\n}\n";
   impl << "}\n";
 
   auto registerName = "CathodeSegmentationCreatorRegisterC" + creatorName.substr(1);
   impl << "class " << registerName << "{ \n";
-  impl << "  public:\n  " << registerName << "() { registerCathodeSegmentationCreator(" << segType << "," << creatorName
-       << "); }\n";
+  impl << "  public:\n  " << registerName << "()\n {\n registerCathodeSegmentationCreator(" << segType << "," << creatorName
+       << ");\n }\n";
   impl << "} a" << registerName << ";\n";
 
   impl << mappingNamespaceEnd(ns);

--- a/o2/mch/mapping/codegen/cathodeSegmentationCommon.cxx
+++ b/o2/mch/mapping/codegen/cathodeSegmentationCommon.cxx
@@ -43,9 +43,13 @@ std::string generateCodeForDetElemIdArray(const rapidjson::Value &detection_elem
   std::sort(deids.begin(), deids.end());
 
   impl << "\n  const std::array<int," << deids.size() << "> detElemIndexToDetElemId{ \n";
+  int nDeIdsPerRow{ 12 };
   for (auto i = 0; i < deids.size(); ++i) {
     impl << deids[i];
     if (i < deids.size() - 1) { impl << ","; }
+    if ((i % nDeIdsPerRow) == (nDeIdsPerRow - 1)) {
+      impl << "\n";
+    }
   }
   impl << "};\n";
   return impl.str();
@@ -55,8 +59,9 @@ std::string generateCodeForCatSegTypeArray(const Value &catsegs, const Value &de
 {
   std::ostringstream impl;
 
-  impl << "\n  const std::array<int," << detection_elements.Size() << "> detElemIndexToSegType{";
+  impl << "\n  const std::array<int," << detection_elements.Size() << "> detElemIndexToSegType{\n";
 
+  int nDeIdxPerRow{ 18 };
   for (int ide = 0; ide < detection_elements.GetArray().Size(); ++ide) {
     const auto &de = detection_elements.GetArray()[ide];
     for (int i = 0; i < catsegs.Size(); ++i) {
@@ -64,6 +69,9 @@ std::string generateCodeForCatSegTypeArray(const Value &catsegs, const Value &de
       if (!strcmp(seg["segtype"].GetString(), de["segtype"].GetString())) {
         impl << i;
         if (ide < detection_elements.GetArray().Size() - 1) { impl << ","; }
+        if ((ide % nDeIdxPerRow) == (nDeIdxPerRow - 1)) {
+          impl << "\n";
+        }
         break;
       }
     }

--- a/o2/mch/mapping/codegen/writer.cxx
+++ b/o2/mch/mapping/codegen/writer.cxx
@@ -19,11 +19,12 @@ namespace codegen {
 
 std::string copyright()
 {
-  return R"(// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+  return R"(// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
@@ -65,14 +66,15 @@ std::string generateNotice(bool standalone)
 {
   std::string notice{
     R"(//
-// This file has been generated. Do not modify it by hand or your changes might be lost.
+// This file has been generated. Do not modify it by hand or your changes might
+// be lost.
 //)"
   };
 
   if (!standalone) {
     notice += R"(
-// This implementation file cannot be used standalone, i.e. it is intended to be included
-// into another implementation file.
+// This implementation file cannot be used standalone, i.e. it is intended to be
+// included into another implementation file.
 //)";
   }
   notice += "\n";


### PR DESCRIPTION
The formatting improvements are needed in order to match the code that is currently committed into the O2 repository.

The generated code still needs to be beautified with clang-format once copied into the O2 source tree.